### PR TITLE
fix: properly export websocket exceptions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 export * from './throttler-module-options.interface';
 export * from './throttler-storage.interface';
+export * from './throttler-ws.exception';
 export * from './throttler.decorator';
 export * from './throttler.exception';
 export * from './throttler.guard';


### PR DESCRIPTION
Previously, `ThrottlerWsException` could only be imported as:

```ts
import { ThrottlerException } from 'nestjs-throttler';
import { ThrottlerWsException } from 'nestjs-throttler/dist/throttler-ws.exception';
```

With this change, it can be imported normally:

```ts
import { ThrottlerException, ThrottlerWsException } from 'nestjs-throttler';
```
