### PR TITLE
fix: add default value for `forRoot` options

### DIFF
--- a/src/throttler.module.ts
+++ b/src/throttler.module.ts
@@ -16,7 +16,7 @@ export class ThrottlerModule {
   /**
    * Register the module synchronously.
    */
-  static forRoot(options?: ThrottlerModuleOptions): DynamicModule {
+  static forRoot(options: ThrottlerModuleOptions = {}): DynamicModule {
     const providers = [...createThrottlerProviders(options), ThrottlerStorageProvider];
     return {
       module: ThrottlerModule,


### PR DESCRIPTION
With a default value for `forRoot` options, devs can now call
`ThrottlerModule.forRoot()` without any errors.

fix #333