### PR TITLE
feat: add key generator option

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ This package comes with a couple of goodies that should be mentioned, first is t
     - [@Throttle()](#throttle)
     - [@SkipThrottle()](#skipthrottle)
   - [Ignoring specific user agents](#ignoring-specific-user-agents)
+  - [Configuring package under proxy](#configuring-package-under-proxy)
   - [ThrottlerStorage](#throttlerstorage)
   - [Working with Websockets](#working-with-websockets)
   - [Working with GraphQL](#working-with-graphql)
@@ -184,6 +185,24 @@ You can use the `ignoreUserAgents` key to ignore specific user agents.
         // Example user agent: Mozilla/5.0 (compatible; Bingbot/2.0; +http://www.bing.com/bingbot.htm)
         new RegExp('bingbot', 'gi'),
       ],
+    }),
+  ],
+})
+export class AppModule {}
+```
+
+### Configuring package under proxy
+
+You can use the `keyGenerator` key to setup a function to generate a unique identifier for each incoming request if you use a proxy.
+
+```ts
+@Module({
+  imports: [
+    ThrottlerModule.forRoot({
+      ttl: 60,
+      limit: 10,
+      // Will generate keys using 'cf-connecting-ip' header.
+      keyGenerator: (req: Record<string, any>) => req.headers['cf-connecting-ip'] || req.ip,
     }),
   ],
 })

--- a/src/throttler-module-options.interface.ts
+++ b/src/throttler-module-options.interface.ts
@@ -17,6 +17,11 @@ export interface ThrottlerModuleOptions {
   ignoreUserAgents?: RegExp[];
 
   /**
+   * A function to generate a unique identifier for each incoming request. Defaults to ip.
+   */
+  keyGenerator?: (req: Record<string, any>) => string;
+
+  /**
    * The storage class to use where all the record will be stored in.
    */
   storage?: any;

--- a/src/throttler.guard.ts
+++ b/src/throttler.guard.ts
@@ -77,7 +77,15 @@ export class ThrottlerGuard implements CanActivate {
       }
     }
 
-    const key = this.generateKey(context, req.ip);
+    let key;
+
+    // Generate custom storage key if appropriate option provided.
+    if (typeof this.options.keyGenerator === 'function') {
+      key = this.options.keyGenerator(req);
+    } else {
+      key = req.ip;
+    }
+
     const ttls = await this.storageService.getRecord(key);
     const nearestExpiryTime = ttls.length > 0 ? Math.ceil((ttls[0] - Date.now()) / 1000) : 0;
 

--- a/src/throttler.guard.ts
+++ b/src/throttler.guard.ts
@@ -81,9 +81,9 @@ export class ThrottlerGuard implements CanActivate {
 
     // Generate custom storage key if appropriate option provided.
     if (typeof this.options.keyGenerator === 'function') {
-      key = this.options.keyGenerator(req);
+      key = this.generateKey(context, this.options.keyGenerator(req));
     } else {
-      key = req.ip;
+      key = this.generateKey(context, req.ip);
     }
 
     const ttls = await this.storageService.getRecord(key);


### PR DESCRIPTION
This PR adds a new option for generating keys. This option helps the developer to reconfigure the package so that it works correctly, for example, under a proxy or under Cloudflare.
```ts
import { APP_GUARD } from '@nestjs/core';
import { ThrottlerGuard, ThrottlerModule } from 'nestjs-throttler';

@Module({
  imports: [
    ThrottlerModule.forRoot({
      ttl: 60,
      limit: 10,
      keyGenerator: (req) => req.headers['cf-connecting-ip'] ?? req.ip,
    }),
  ],
  providers: [
    {
      provide: APP_GUARD,
      useClass: ThrottlerGuard,
    },
  ],
})
export class AppModule {}
````