### PR TITLE
Handle scenarios for requests/responses where rawBody is being used

### DIFF
--- a/src/throttler.guard.ts
+++ b/src/throttler.guard.ts
@@ -65,9 +65,9 @@ export class ThrottlerGuard implements CanActivate {
     const { req, res } = this.getRequestResponse(context);
 
     // Return early if the current user agent should be ignored.
-    if (Array.isArray(this.options.ignoreUserAgents)) {
+    if (Array.isArray(this.options.ignoreUserAgents) && req.headers) {
       for (const pattern of this.options.ignoreUserAgents) {
-        if (req.headers && pattern.test(req.headers['user-agent'])) {
+        if (pattern.test(req.headers['user-agent'])) {
           return true;
         }
       }

--- a/src/throttler.guard.ts
+++ b/src/throttler.guard.ts
@@ -67,7 +67,7 @@ export class ThrottlerGuard implements CanActivate {
     // Return early if the current user agent should be ignored.
     if (Array.isArray(this.options.ignoreUserAgents)) {
       for (const pattern of this.options.ignoreUserAgents) {
-        if (pattern.test(req.headers['user-agent'])) {
+        if (req.headers && pattern.test(req.headers['user-agent'])) {
           return true;
         }
       }

--- a/src/throttler.guard.ts
+++ b/src/throttler.guard.ts
@@ -77,8 +77,8 @@ export class ThrottlerGuard implements CanActivate {
     const ttls = await this.storageService.getRecord(key);
     const nearestExpiryTime = ttls.length > 0 ? Math.ceil((ttls[0] - Date.now()) / 1000) : 0;
 
-    // The response might be `undefined` in some cases. For example, not having
-    // bodyParser to be `true` and using a rawBody parser will result in this.
+    // The response might be `undefined` in some cases. For example, having
+    // bodyParser to be `false` and using a rawBody parser.
     if (res) {
       // Throw an error when the user reached their limit.
       if (ttls.length >= limit) {


### PR DESCRIPTION
Hi,

We're having a project where we use the Throttler being defined globally in the app module and we're listening for stripe webhook events with the [@golevelup/nestjs-stripe](https://www.npmjs.com/package/@golevelup/nestjs-stripe) module.

We've added `{ bodyParser: false }` inside the `main.ts` followed by defining the following setup in the app module:

```ts
export class AppModule implements NestModule {
  configure(consumer: MiddlewareConsumer): void {
    consumer
      .apply(RawBodyMiddleware)
      .forRoutes({
        path: 'stripe/webhook',
        method: RequestMethod.ALL,
      })
      .apply(JsonBodyMiddleware)
      .forRoutes('*')
  }
}
```

After triggering a Stripe event, this resulted in the following error:

```
TypeError: Cannot read property 'header' of undefined
    at ThrottlerGuard.handleRequest (/Users/<username>/projects/<my-project>/node_modules/@nestjs/throttler/dist/throttler.guard.js:68:13)
    at processTicksAndRejections (internal/process/task_queues.js:93:5)
    at async GuardsConsumer.tryActivate (/Users/<username>/projects/<my-project>/node_modules/@nestjs/core/guards/guards-consumer.js:16:17)
    at async canActivateFn (/Users/<username>/projects/<my-project>/node_modules/@nestjs/core/helpers/external-context-creator.js:162:33)
    at async target (/Users/<username>/projects/<my-project>/node_modules/@nestjs/core/helpers/external-context-creator.js:75:31)
    at async Object.handler (/Users/<username>/projects/<my-project>/node_modules/@nestjs/core/helpers/external-proxy.js:9:24)
    at async Promise.all (index 0)
    at async StripeWebhookService.handleWebhook (/Users/<username>/projects/<my-project>/node_modules/@golevelup/nestjs-stripe/lib/stripe.module.js:108:17)
    at async StripeWebhookController.handleWebhook (/Users/<username>/projects/<my-project>/node_modules/@golevelup/nestjs-stripe/lib/stripe.webhook.controller.js:34:9)
```

Basically, the problem is that in this scenario, the `res` is `undefined` in the throttler guard and I don't really know why, but adding an if-statement around it will fix the problem.

I thought to myself, I could add `ignoreUserAgents: [/^Stripe\/[\d.]+/]` as well, but this resulted in the error `Cannot read property 'user-agent' of undefined` so I've also improved that check by checking if `req.headers` exists.

There's no way for me to use stripe with throttler globally configured together, so we're disabling throttler in our project at this point. I suggest we merge this crucial change ASAP and do a deploy to NPM as well.