### PR TITLE
fix: package name of throttler

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ how many times an endpoint can be hit before returning a 429.
 
 ```ts
 import { APP_GUARD } from '@nestjs/core';
-import { ThrottlerGuard, ThrottlerModule } from 'nestjs-throttler';
+import { ThrottlerGuard, ThrottlerModule } from '@nestjs/throttler';
 
 @Module({
   imports: [


### PR DESCRIPTION
I am using this package at work and the  guard is imported from '@nestjs/throttler'