### PR TITLE
Rewrite throttle logic to prevent request flooding

### DIFF
--- a/.changeset/violet-islands-compare.md
+++ b/.changeset/violet-islands-compare.md
@@ -1,0 +1,30 @@
+---
+'@nestjs/throttler': major
+---
+
+Rewrite the storage service to better handle large numbers of operations
+
+## Why
+
+The initial behavior was that `getRecord()` returned an list of sorted TTL
+timestamps, then if it didn't reach the limit, it will call `addRecord()`.
+This change was made based on the use of the Redis storage community package
+where it was found how to prevent this issue. It was found out that
+[express-rate-limit](https://github.com/express-rate-limit/express-rate-limit)
+is incrementing a single number and returning the information in a single
+roundtrip, which is significantly faster than how NestJS throttler works by
+called `getRecord()`, then `addRecord`.
+
+## Breaking Changes
+
+- removed `getRecord`
+- `addRecord(key: string, ttl: number): Promise<number[]>;` changes to `increment(key: string, ttl: number): Promise<ThrottlerStorageRecord>;`
+
+## How to Migrate
+
+If you are just _using_ the throttler library, you're already covered. No
+changes necessary to your code, version 4.0.0 will work as is.
+
+If you are providing a custom storage, you will need to remove your current
+service's `getRecord` method and rename `addRecord` to `incremenet` while
+adhering to the new interface and returning an `ThrottlerStorageRecord` object

--- a/README.md
+++ b/README.md
@@ -215,8 +215,8 @@ The interface looks like this:
 
 ```ts
 export interface ThrottlerStorage {
-  storage: Record<string, { totalHits: number; timeToExpire: number }>;
-  addRecord(key: string, ttl: number): Promise<{ totalHits: number; timeToExpire: number }>;
+  storage: Record<string, ThrottlerStorageOptions>;
+  increment(key: string, ttl: number): Promise<ThrottlerStorageRecord>;
 }
 ```
 
@@ -258,13 +258,12 @@ export class WsThrottlerGuard extends ThrottlerGuard {
       .filter((obj) => obj)
       .shift().remoteAddress;
     const key = this.generateKey(context, ip);
-    const ttls = await this.storageService.getRecord(key);
+    const { totalHits } = await this.storageService.increment(key, ttl);
 
-    if (ttls.length >= limit) {
+    if (totalHits > limit) {
       throw new ThrottlerException();
     }
 
-    await this.storageService.addRecord(key, ttl);
     return true;
   }
 }

--- a/README.md
+++ b/README.md
@@ -31,7 +31,6 @@ For an overview of the community storage providers, see [Community Storage Provi
 
 This package comes with a couple of goodies that should be mentioned, first is the `ThrottlerModule`.
 
-
 ## Installation
 
 ```bash
@@ -216,8 +215,8 @@ The interface looks like this:
 
 ```ts
 export interface ThrottlerStorage {
-  getRecord(key: string): Promise<number[]>;
-  addRecord(key: string, ttl: number): Promise<void>;
+  storage: Record<string, { totalHits: number; timeToExpire: number }>;
+  addRecord(key: string, ttl: number): Promise<{ totalHits: number; timeToExpire: number }>;
 }
 ```
 

--- a/src/throttler-storage-options.interface.ts
+++ b/src/throttler-storage-options.interface.ts
@@ -1,0 +1,13 @@
+export interface ThrottlerStorageOptions {
+  /**
+   * Amount of requests done by a specific user (partially based on IP).
+   */
+  totalHits: number;
+
+  /**
+   * Unix timestamp in milliseconds when the `totalHits` expire.
+   */
+  expiresAt: number;
+}
+
+export const ThrottlerStorageOptions = Symbol('ThrottlerStorageOptions');

--- a/src/throttler-storage-record.interface.ts
+++ b/src/throttler-storage-record.interface.ts
@@ -10,4 +10,4 @@ export interface ThrottlerStorageRecord {
   timeToExpire: number;
 }
 
-export const ThrottlerStorageRecordOptions = Symbol('ThrottlerStorageRecordOptions');
+export const ThrottlerStorageRecord = Symbol('ThrottlerStorageRecord');

--- a/src/throttler-storage-record.interface.ts
+++ b/src/throttler-storage-record.interface.ts
@@ -1,0 +1,13 @@
+export interface ThrottlerStorageRecord {
+  /**
+   * Amount of requests done by a specific user (partially based on IP).
+   */
+  totalHits: number;
+
+  /**
+   * Amount of seconds when the `totalHits` should expire.
+   */
+  timeToExpire: number;
+}
+
+export const ThrottlerStorageRecordOptions = Symbol('ThrottlerStorageRecordOptions');

--- a/src/throttler-storage.interface.ts
+++ b/src/throttler-storage.interface.ts
@@ -1,21 +1,18 @@
+import { ThrottlerStorageOptions } from './throttler-storage-options.interface';
+import { ThrottlerStorageRecord } from './throttler-storage-record.interface';
+
 export interface ThrottlerStorage {
   /**
    * The internal storage with all the request records.
    * The key is a hashed key based on the current context and IP.
-   * The value of is an object contains the two keys:
-   *   - totalHits: Amount of requests being done.
-   *   - expiresAt: Epoch milliseconds when this key expires.
    */
-  storage: Record<string, { totalHits: number; expiresAt: number }>;
+  storage: Record<string, ThrottlerStorageOptions>;
 
   /**
-   * Add a record to the storage. The record will automatically be removed from
-   * the storage once its TTL has been reached.
-   * The return object contains two keys:
-   *   - totalHits: Amount of requestings being done.
-   *   - timeToExpire: Amount of seconds remaining until this record expires.
+   * Increment the amount of requests for a given record. The record will
+   * automatically be removed from the storage once its TTL has been reached.
    */
-  addRecord(key: string, ttl: number): Promise<{ totalHits: number; timeToExpire: number }>;
+  increment(key: string, ttl: number): Promise<ThrottlerStorageRecord>;
 }
 
 export const ThrottlerStorage = Symbol('ThrottlerStorage');

--- a/src/throttler-storage.interface.ts
+++ b/src/throttler-storage.interface.ts
@@ -3,14 +3,17 @@ export interface ThrottlerStorage {
    * The internal storage with all the request records.
    * The key is a hashed key based on the current context and IP.
    * The value of is an object contains the two keys:
-   *   - totalHits    (number): Amount of requests being done.
-   *   - timeToExpire (number): Amount of seconds until this key expires.
+   *   - totalHits: Amount of requests being done.
+   *   - expiresAt: Epoch milliseconds when this key expires.
    */
-  storage: Record<string, { totalHits: number; timeToExpire: number }>;
+  storage: Record<string, { totalHits: number; expiresAt: number }>;
 
   /**
    * Add a record to the storage. The record will automatically be removed from
    * the storage once its TTL has been reached.
+   * The return object contains two keys:
+   *   - totalHits: Amount of requestings being done.
+   *   - timeToExpire: Amount of seconds remaining until this record expires.
    */
   addRecord(key: string, ttl: number): Promise<{ totalHits: number; timeToExpire: number }>;
 }

--- a/src/throttler-storage.interface.ts
+++ b/src/throttler-storage.interface.ts
@@ -2,21 +2,17 @@ export interface ThrottlerStorage {
   /**
    * The internal storage with all the request records.
    * The key is a hashed key based on the current context and IP.
-   * The value of each item wil be an array of epoch times which indicate all
-   * the request's ttls in an ascending order.
+   * The value of is an object contains the two keys:
+   *   - totalHits    (number): Amount of requests being done.
+   *   - timeToExpire (number): Amount of seconds until this expiration.
    */
-  storage: Record<string, number[]>;
-
-  /**
-   * Get a record via its key and return all its request ttls.
-   */
-  getRecord(key: string): Promise<number[]>;
+  storage: Record<string, { totalHits: number; timeToExpire: number }>;
 
   /**
    * Add a record to the storage. The record will automatically be removed from
    * the storage once its TTL has been reached.
    */
-  addRecord(key: string, ttl: number): Promise<void>;
+  addRecord(key: string, ttl: number): Promise<{ totalHits: number; timeToExpire: number }>;
 }
 
 export const ThrottlerStorage = Symbol('ThrottlerStorage');

--- a/src/throttler-storage.interface.ts
+++ b/src/throttler-storage.interface.ts
@@ -4,7 +4,7 @@ export interface ThrottlerStorage {
    * The key is a hashed key based on the current context and IP.
    * The value of is an object contains the two keys:
    *   - totalHits    (number): Amount of requests being done.
-   *   - timeToExpire (number): Amount of seconds until this expiration.
+   *   - timeToExpire (number): Amount of seconds until this key expires.
    */
   storage: Record<string, { totalHits: number; timeToExpire: number }>;
 

--- a/src/throttler.guard.spec.ts
+++ b/src/throttler.guard.spec.ts
@@ -14,7 +14,7 @@ class ThrottlerStorageServiceMock implements ThrottlerStorage {
     return this._storage;
   }
 
-  getExpirationTime(key: string): number {
+  private getExpirationTime(key: string): number {
     return Math.floor((this.storage[key].expiresAt - Date.now()) / 1000);
   }
 

--- a/src/throttler.guard.spec.ts
+++ b/src/throttler.guard.spec.ts
@@ -7,20 +7,23 @@ import { ThrottlerException } from './throttler.exception';
 import { ThrottlerGuard } from './throttler.guard';
 
 class ThrottlerStorageServiceMock implements ThrottlerStorage {
-  private _storage: Record<string, { totalHits: number; timeToExpire: number }> = {};
-  get storage(): Record<string, { totalHits: number; timeToExpire: number }> {
+  private _storage: Record<string, { totalHits: number; expiresAt: number }> = {};
+  get storage(): Record<string, { totalHits: number; expiresAt: number }> {
     return this._storage;
   }
 
   async addRecord(key: string, ttl: number): Promise<{ totalHits: number; timeToExpire: number }> {
     const ttlMilliseconds = ttl * 1000;
     if (!this.storage[key]) {
-      this.storage[key] = { totalHits: 0, timeToExpire: ttlMilliseconds };
+      this.storage[key] = { totalHits: 0, expiresAt: Date.now() + ttlMilliseconds };
     }
 
     this.storage[key].totalHits++;
 
-    return this.storage[key];
+    return {
+      totalHits: this.storage[key].totalHits,
+      timeToExpire: Math.floor((this.storage[key].expiresAt - Date.now()) / 1000),
+    };
   }
 }
 

--- a/src/throttler.guard.spec.ts
+++ b/src/throttler.guard.spec.ts
@@ -7,22 +7,20 @@ import { ThrottlerException } from './throttler.exception';
 import { ThrottlerGuard } from './throttler.guard';
 
 class ThrottlerStorageServiceMock implements ThrottlerStorage {
-  private _storage: Record<string, number[]> = {};
-  get storage(): Record<string, number[]> {
+  private _storage: Record<string, { totalHits: number; timeToExpire: number }> = {};
+  get storage(): Record<string, { totalHits: number; timeToExpire: number }> {
     return this._storage;
   }
 
-  async getRecord(key: string): Promise<number[]> {
-    return this.storage[key] || [];
-  }
-
-  async addRecord(key: string, ttl: number): Promise<void> {
+  async addRecord(key: string, ttl: number): Promise<{ totalHits: number; timeToExpire: number }> {
     const ttlMilliseconds = ttl * 1000;
     if (!this.storage[key]) {
-      this.storage[key] = [];
+      this.storage[key] = { totalHits: 0, timeToExpire: ttlMilliseconds };
     }
 
-    this.storage[key].push(Date.now() + ttlMilliseconds);
+    this.storage[key].totalHits++;
+
+    return this.storage[key];
   }
 }
 

--- a/src/throttler.guard.ts
+++ b/src/throttler.guard.ts
@@ -77,7 +77,7 @@ export class ThrottlerGuard implements CanActivate {
     }
     const tracker = this.getTracker(req);
     const key = this.generateKey(context, tracker);
-    const { totalHits, timeToExpire } = await this.storageService.addRecord(key, ttl);
+    const { totalHits, timeToExpire } = await this.storageService.increment(key, ttl);
 
     // Throw an error when the user reached their limit.
     if (totalHits > limit) {

--- a/src/throttler.guard.ts
+++ b/src/throttler.guard.ts
@@ -77,22 +77,20 @@ export class ThrottlerGuard implements CanActivate {
     }
     const tracker = this.getTracker(req);
     const key = this.generateKey(context, tracker);
-    const ttls = await this.storageService.getRecord(key);
-    const nearestExpiryTime = ttls.length > 0 ? Math.ceil((ttls[0] - Date.now()) / 1000) : 0;
+    const { totalHits, timeToExpire } = await this.storageService.addRecord(key, ttl);
 
     // Throw an error when the user reached their limit.
-    if (ttls.length >= limit) {
-      res.header('Retry-After', nearestExpiryTime);
+    if (totalHits > limit) {
+      res.header('Retry-After', timeToExpire);
       this.throwThrottlingException(context);
     }
 
     res.header(`${this.headerPrefix}-Limit`, limit);
     // We're about to add a record so we need to take that into account here.
     // Otherwise the header says we have a request left when there are none.
-    res.header(`${this.headerPrefix}-Remaining`, Math.max(0, limit - (ttls.length + 1)));
-    res.header(`${this.headerPrefix}-Reset`, nearestExpiryTime);
+    res.header(`${this.headerPrefix}-Remaining`, Math.max(0, limit - totalHits));
+    res.header(`${this.headerPrefix}-Reset`, timeToExpire);
 
-    await this.storageService.addRecord(key, ttl);
     return true;
   }
 

--- a/src/throttler.service.ts
+++ b/src/throttler.service.ts
@@ -3,31 +3,29 @@ import { ThrottlerStorage } from './throttler-storage.interface';
 
 @Injectable()
 export class ThrottlerStorageService implements ThrottlerStorage, OnApplicationShutdown {
-  private _storage: Record<string, number[]> = {};
+  private _storage: Record<string, { totalHits: number; timeToExpire: number }> = {};
   private timeoutIds: NodeJS.Timeout[] = [];
 
-  get storage(): Record<string, number[]> {
+  get storage(): Record<string, { totalHits: number; timeToExpire: number }> {
     return this._storage;
   }
 
-  async getRecord(key: string): Promise<number[]> {
-    return this.storage[key] || [];
-  }
-
-  async addRecord(key: string, ttl: number): Promise<void> {
+  async addRecord(key: string, ttl: number): Promise<{ totalHits: number; timeToExpire: number }> {
     const ttlMilliseconds = ttl * 1000;
     if (!this.storage[key]) {
-      this.storage[key] = [];
+      this.storage[key] = { totalHits: 0, timeToExpire: ttlMilliseconds };
     }
 
-    this.storage[key].push(Date.now() + ttlMilliseconds);
+    this.storage[key].totalHits++;
 
     const timeoutId = setTimeout(() => {
-      this.storage[key].shift();
+      this.storage[key].totalHits--;
       clearTimeout(timeoutId);
       this.timeoutIds = this.timeoutIds.filter((id) => id != timeoutId);
     }, ttlMilliseconds);
     this.timeoutIds.push(timeoutId);
+
+    return this.storage[key];
   }
 
   onApplicationShutdown() {

--- a/src/throttler.service.ts
+++ b/src/throttler.service.ts
@@ -1,33 +1,56 @@
 import { Injectable, OnApplicationShutdown } from '@nestjs/common';
+import { ThrottlerStorageOptions } from './throttler-storage-options.interface';
+import { ThrottlerStorageRecord } from './throttler-storage-record.interface';
 import { ThrottlerStorage } from './throttler-storage.interface';
 
 @Injectable()
 export class ThrottlerStorageService implements ThrottlerStorage, OnApplicationShutdown {
-  private _storage: Record<string, { totalHits: number; expiresAt: number }> = {};
+  private _storage: Record<string, ThrottlerStorageOptions> = {};
   private timeoutIds: NodeJS.Timeout[] = [];
 
-  get storage(): Record<string, { totalHits: number; expiresAt: number }> {
+  get storage(): Record<string, ThrottlerStorageOptions> {
     return this._storage;
   }
 
-  async addRecord(key: string, ttl: number): Promise<{ totalHits: number; timeToExpire: number }> {
-    const ttlMilliseconds = ttl * 1000;
-    if (!this.storage[key]) {
-      this.storage[key] = { totalHits: 0, expiresAt: Date.now() + ttlMilliseconds };
-    }
+  /**
+   * Get the expiration time in seconds from a single record.
+   */
+  private getExpirationTime(key: string): number {
+    return Math.floor((this.storage[key].expiresAt - Date.now()) / 1000);
+  }
 
-    this.storage[key].totalHits++;
-
+  /**
+   * Set the expiration time for a given key.
+   */
+  private setExpirationTime(key: string, ttlMilliseconds: number): void {
     const timeoutId = setTimeout(() => {
       this.storage[key].totalHits--;
       clearTimeout(timeoutId);
       this.timeoutIds = this.timeoutIds.filter((id) => id != timeoutId);
     }, ttlMilliseconds);
     this.timeoutIds.push(timeoutId);
+  }
+
+  async increment(key: string, ttl: number): Promise<ThrottlerStorageRecord> {
+    const ttlMilliseconds = ttl * 1000;
+    if (!this.storage[key]) {
+      this.storage[key] = { totalHits: 0, expiresAt: Date.now() + ttlMilliseconds };
+    }
+
+    let timeToExpire = this.getExpirationTime(key);
+
+    // Reset the timeToExpire once it has been expired.
+    if (timeToExpire <= 0) {
+      this.storage[key].expiresAt = Date.now() + ttlMilliseconds;
+      timeToExpire = this.getExpirationTime(key);
+    }
+
+    this.storage[key].totalHits++;
+    this.setExpirationTime(key, ttlMilliseconds);
 
     return {
       totalHits: this.storage[key].totalHits,
-      timeToExpire: Math.floor((this.storage[key].expiresAt - Date.now()) / 1000),
+      timeToExpire,
     };
   }
 

--- a/test/controller.e2e-spec.ts
+++ b/test/controller.e2e-spec.ts
@@ -50,7 +50,7 @@ describe.each`
         expect(response.headers).not.toMatchObject({
           'x-ratelimit-limit': '2',
           'x-ratelimit-remaining': '1',
-          'x-ratelimit-reset': /\d+/,
+          'x-ratelimit-reset': /^\d+$/,
         });
       });
       it('GET /ignore-user-agents', async () => {
@@ -61,7 +61,7 @@ describe.each`
         expect(response.headers).not.toMatchObject({
           'x-ratelimit-limit': '2',
           'x-ratelimit-remaining': '1',
-          'x-ratelimit-reset': /\d+/,
+          'x-ratelimit-reset': /^\d+$/,
         });
       });
       it('GET /', async () => {
@@ -70,7 +70,7 @@ describe.each`
         expect(response.headers).toMatchObject({
           'x-ratelimit-limit': '2',
           'x-ratelimit-remaining': '1',
-          'x-ratelimit-reset': /\d+/,
+          'x-ratelimit-reset': /^\d+$/,
         });
       });
     });
@@ -91,13 +91,13 @@ describe.each`
             expect(response.headers).toMatchObject({
               'x-ratelimit-limit': limit.toString(),
               'x-ratelimit-remaining': (limit - (i + 1)).toString(),
-              'x-ratelimit-reset': /\d+/,
+              'x-ratelimit-reset': /^\d+$/,
             });
           }
           const errRes = await httPromise(appUrl + '/limit' + url, method);
           expect(errRes.data).toMatchObject({ statusCode: 429, message: /ThrottlerException/ });
           expect(errRes.headers).toMatchObject({
-            'retry-after': /\d+/,
+            'retry-after': /^\d+$/,
           });
           expect(errRes.status).toBe(429);
         },
@@ -113,7 +113,7 @@ describe.each`
         expect(response.headers).toMatchObject({
           'x-ratelimit-limit': '5',
           'x-ratelimit-remaining': '4',
-          'x-ratelimit-reset': /\d+/,
+          'x-ratelimit-reset': /^\d+$/,
         });
       });
     });
@@ -147,7 +147,7 @@ describe('SkipIf suite', () => {
       expect(response.headers).not.toMatchObject({
         'x-ratelimit-limit': '5',
         'x-ratelimit-remaining': '4',
-        'x-ratelimit-reset': /\d+/,
+        'x-ratelimit-reset': /^\d+$/,
       });
     }
     await app.close();


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: 1303


## What is the new behavior?

I've made some adjustments based on my suggestion in #1303 in order to add a single record and retrieve all info in a single function. This also allows external storage providers made by the community to add and retrieve in a single roundtrip (i.e. my [redis storage provider](https://github.com/kkoomen/nestjs-throttler-storage-redis)).

The initial behavior was that `getRecord()` returned an list of sorted TTL timestamps, then if it didn't reach the limit, it will call `addRecord()`. This change was made based on Redis where I fiddled around on how to prevent this issue. I found out that [express-rate-limit](https://github.com/express-rate-limit/express-rate-limit) is incrementing a single number and returning the information in a single roundtrip, which is significantly faster than how NestJS throttler works by called `getRecord()`, then `addRecord`.

The [rate-limit-redis](https://github.com/wyattjoh/rate-limit-redis) did have a very fast version with `EVALSHA`. I tried to integrate the `EVALSHA` script they used into my own storage provider, which immediately worked. Then I adjust the changes to my version, but that did not work all the way. There were still coming +10 requests through with my version. This version was much faster than before where ±400 requests came through, but still wasn't not perfect. This was because `SMEMBERS <key>` that I personally used - which returns a list of TTL timestamps from `<key>` - seems to be much slower than it is to increment a single number and retrieve this number. Therefore, I made the new logic similar to how [express-rate-limit](https://github.com/express-rate-limit/express-rate-limit) works by requiring two things from the `addRecord()` (which I have renamed in this PR): 
- `totalHits`: amount of requests done for `key`
- `timeToExpire`: amount of seconds until the `totalHits` expire for `key`

## Does this PR introduce a breaking change?
- [x] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

Breaking `ThrottlerStorage` changes:
- removed `getRecord`
- `addRecord(key: string, ttl: number): Promise<number[]>;` changes to `increment(key: string, ttl: number): Promise<ThrottlerStorageRecord>;`

## Other information
