### PR TITLE
Issue/1660

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ export class ThrottlerBehindProxyGuard extends ThrottlerGuard {
   return new Promise<string>((resolve, reject) => {
     const tracker = request.ips.length > 0 ? request.ips[0] : request.ip; // individualize IP extraction to meet your own needs
     resolve(tracker);
-  }); 
+  });
   }
 }
 
@@ -243,6 +243,10 @@ The following options are valid for the object passed to the array of the `Throt
   <tr>
     <td><code>limit</code></td>
     <td>the maximum number of requests within the TTL limit</td>
+  </tr>
+  <tr>
+    <td><code>blockDuration</code></td>
+    <td>the number of milliseconds that request will be blocked for that time</td>
   </tr>
   <tr>
     <td><code>ignoreUserAgents</code></td>

--- a/src/throttler-module-options.interface.ts
+++ b/src/throttler-module-options.interface.ts
@@ -27,6 +27,11 @@ export interface ThrottlerOptions {
   ttl: Resolvable<number>;
 
   /**
+   * The number of millisecond the request will be blocked
+   */
+  blockDuration?: Resolvable<number>;
+
+  /**
    * The user agents that should be ignored (checked against the User-Agent header).
    */
   ignoreUserAgents?: RegExp[];

--- a/src/throttler-storage-options.interface.ts
+++ b/src/throttler-storage-options.interface.ts
@@ -2,12 +2,22 @@ export interface ThrottlerStorageOptions {
   /**
    * Amount of requests done by a specific user (partially based on IP).
    */
-  totalHits: number;
+  totalHits: Record<string, number>;
+
+  /**
+   * Unix timestamp in milliseconds that indicates `ttl` lifetime
+   */
+  expiresAt: number;
+
+  /**
+   * Define the request is blocked or not.
+   */
+  isBlocked: boolean;
 
   /**
    * Unix timestamp in milliseconds when the `totalHits` expire.
    */
-  expiresAt: number;
+  blockExpiresAt: number;
 }
 
 export const ThrottlerStorageOptions = Symbol('ThrottlerStorageOptions');

--- a/src/throttler-storage-record.interface.ts
+++ b/src/throttler-storage-record.interface.ts
@@ -5,9 +5,19 @@ export interface ThrottlerStorageRecord {
   totalHits: number;
 
   /**
-   * Amount of seconds when the `totalHits` should expire.
+   * Amount of seconds when the `ttl` should expire.
    */
   timeToExpire: number;
+
+  /**
+   * Define the request is blocked or not.
+   */
+  isBlocked: boolean;
+
+  /**
+   * Amount of seconds when the `totalHits` should expire.
+   */
+  timeToBlockExpire: number;
 }
 
 export const ThrottlerStorageRecord = Symbol('ThrottlerStorageRecord');

--- a/src/throttler-storage.interface.ts
+++ b/src/throttler-storage.interface.ts
@@ -5,7 +5,13 @@ export interface ThrottlerStorage {
    * Increment the amount of requests for a given record. The record will
    * automatically be removed from the storage once its TTL has been reached.
    */
-  increment(key: string, ttl: number): Promise<ThrottlerStorageRecord>;
+  increment(
+    key: string,
+    ttl: number,
+    limit: number,
+    blockDuration: number,
+    throttlerName: string,
+  ): Promise<ThrottlerStorageRecord>;
 }
 
 export const ThrottlerStorage = Symbol('ThrottlerStorage');

--- a/src/throttler.decorator.ts
+++ b/src/throttler.decorator.ts
@@ -6,6 +6,7 @@ import { Resolvable } from './throttler-module-options.interface';
 interface ThrottlerMethodOrControllerOptions {
   limit?: Resolvable<number>;
   ttl?: Resolvable<number>;
+  blockDuration?: Resolvable<number>;
 }
 
 function setThrottlerMetadata(

--- a/src/throttler.service.ts
+++ b/src/throttler.service.ts
@@ -9,7 +9,7 @@ import { ThrottlerStorage } from './throttler-storage.interface';
 @Injectable()
 export class ThrottlerStorageService implements ThrottlerStorage, OnApplicationShutdown {
   private _storage: Record<string, ThrottlerStorageOptions> = {};
-  private timeoutIds: NodeJS.Timeout[] = [];
+  private timeoutIds: Record<string, NodeJS.Timeout[]> = {};
 
   get storage(): Record<string, ThrottlerStorageOptions> {
     return this._storage;
@@ -23,21 +23,74 @@ export class ThrottlerStorageService implements ThrottlerStorage, OnApplicationS
   }
 
   /**
-   * Set the expiration time for a given key.
+   * Get the block expiration time in seconds from a single record.
    */
-  private setExpirationTime(key: string, ttlMilliseconds: number): void {
-    const timeoutId = setTimeout(() => {
-      this.storage[key].totalHits--;
-      clearTimeout(timeoutId);
-      this.timeoutIds = this.timeoutIds.filter((id) => id != timeoutId);
-    }, ttlMilliseconds);
-    this.timeoutIds.push(timeoutId);
+  private getBlockExpirationTime(key: string): number {
+    return Math.floor((this.storage[key].blockExpiresAt - Date.now()) / 1000);
   }
 
-  async increment(key: string, ttl: number): Promise<ThrottlerStorageRecord> {
+  /**
+   * Set the expiration time for a given key.
+   */
+  private setExpirationTime(key: string, ttlMilliseconds: number, throttlerName: string): void {
+    const timeoutId = setTimeout(() => {
+      this.storage[key].totalHits[throttlerName]--;
+      clearTimeout(timeoutId);
+      this.timeoutIds[throttlerName] = this.timeoutIds[throttlerName].filter(
+        (id) => id != timeoutId,
+      );
+    }, ttlMilliseconds);
+    this.timeoutIds[throttlerName].push(timeoutId);
+  }
+
+  /**
+   * Clear the expiration time related to the throttle
+   */
+  private clearExpirationTimes(throttlerName: string) {
+    this.timeoutIds[throttlerName].forEach(clearTimeout);
+    this.timeoutIds[throttlerName] = [];
+  }
+
+  /**
+   * Reset the request blockage
+   */
+  private resetBlockdRequest(key: string, throttlerName: string) {
+    this.storage[key].isBlocked = false;
+    this.storage[key].totalHits[throttlerName] = 0;
+    this.clearExpirationTimes(throttlerName);
+  }
+
+  /**
+   * Increase the `totalHit` count and sent it to decrease queue
+   */
+  private fireHitCount(key: string, throttlerName: string, ttl: number) {
+    this.storage[key].totalHits[throttlerName]++;
+    this.setExpirationTime(key, ttl, throttlerName);
+  }
+
+  async increment(
+    key: string,
+    ttl: number,
+    limit: number,
+    blockDuration: number,
+    throttlerName: string,
+  ): Promise<ThrottlerStorageRecord> {
     const ttlMilliseconds = ttl;
+    const blockDurationMilliseconds = blockDuration;
+
+    if (!this.timeoutIds[throttlerName]) {
+      this.timeoutIds[throttlerName] = [];
+    }
+
     if (!this.storage[key]) {
-      this.storage[key] = { totalHits: 0, expiresAt: Date.now() + ttlMilliseconds };
+      this.storage[key] = {
+        totalHits: {
+          [throttlerName]: 0,
+        },
+        expiresAt: Date.now() + ttlMilliseconds,
+        blockExpiresAt: 0,
+        isBlocked: false,
+      };
     }
 
     let timeToExpire = this.getExpirationTime(key);
@@ -48,16 +101,36 @@ export class ThrottlerStorageService implements ThrottlerStorage, OnApplicationS
       timeToExpire = this.getExpirationTime(key);
     }
 
-    this.storage[key].totalHits++;
-    this.setExpirationTime(key, ttlMilliseconds);
+    if (!this.storage[key].isBlocked) {
+      this.fireHitCount(key, throttlerName, ttlMilliseconds);
+    }
+
+    // Reset the blockExpiresAt once it gets blocked
+    if (this.storage[key].totalHits[throttlerName] > limit && !this.storage[key].isBlocked) {
+      this.storage[key].isBlocked = true;
+      this.storage[key].blockExpiresAt = Date.now() + blockDurationMilliseconds;
+    }
+
+    const timeToBlockExpire = this.getBlockExpirationTime(key);
+
+    // Reset time blocked request
+    if (timeToBlockExpire <= 0 && this.storage[key].isBlocked) {
+      this.resetBlockdRequest(key, throttlerName);
+      this.fireHitCount(key, throttlerName, ttlMilliseconds);
+    }
 
     return {
-      totalHits: this.storage[key].totalHits,
+      totalHits: this.storage[key].totalHits[throttlerName],
       timeToExpire,
+      isBlocked: this.storage[key].isBlocked,
+      timeToBlockExpire: timeToBlockExpire,
     };
   }
 
   onApplicationShutdown() {
-    this.timeoutIds.forEach(clearTimeout);
+    const throttleNames = Object.keys(this.timeoutIds);
+    throttleNames.forEach((key) => {
+      this.timeoutIds[key].forEach(clearTimeout);
+    });
   }
 }

--- a/test/app/controllers/limit.controller.ts
+++ b/test/app/controllers/limit.controller.ts
@@ -2,7 +2,7 @@ import { Controller, Get } from '@nestjs/common';
 import { Throttle, seconds } from '../../../src';
 import { AppService } from '../app.service';
 
-@Throttle({ default: { limit: 2, ttl: seconds(10) } })
+@Throttle({ default: { limit: 2, ttl: seconds(10), blockDuration: seconds(20) } })
 @Controller('limit')
 export class LimitController {
   constructor(private readonly appService: AppService) {}
@@ -11,7 +11,7 @@ export class LimitController {
     return this.appService.success();
   }
 
-  @Throttle({ default: { limit: 5, ttl: seconds(10) } })
+  @Throttle({ default: { limit: 5, ttl: seconds(10), blockDuration: seconds(20) } })
   @Get('higher')
   getHigher() {
     return this.appService.success();


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Currently, when a user exceeds their request limit within a defined time window **(`ttl`)**, their requests are blocked for a fixed duration tied to the **`ttl`**.

Issue Number: 1660


## What is the new behavior?
I introduced a new option called `blockDuration` when importing the throttler module option. If users choose not to specify `blockDuration`, the system will fall back to the default behavior, which relies on the ttl.


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
