### PR TITLE
fix: properly handle the object passed to the skip throttle decorator

### DIFF
--- a/.changeset/twenty-papayas-bathe.md
+++ b/.changeset/twenty-papayas-bathe.md
@@ -1,0 +1,5 @@
+---
+'@nestjs/throttler': patch
+---
+
+Correctly assign metadata for multiple throttlers passed to `@SkipThrottle()`

--- a/src/throttler.decorator.ts
+++ b/src/throttler.decorator.ts
@@ -57,14 +57,11 @@ export const SkipThrottle = (
     propertyKey?: string | symbol,
     descriptor?: TypedPropertyDescriptor<any>,
   ) => {
+    const reflectionTarget = descriptor?.value ?? target;
     for (const key in skip) {
-      if (descriptor) {
-        Reflect.defineMetadata(THROTTLER_SKIP + key, skip[key], descriptor.value);
-        return descriptor;
-      }
-      Reflect.defineMetadata(THROTTLER_SKIP + key, skip[key], target);
-      return target;
+      Reflect.defineMetadata(THROTTLER_SKIP + key, skip[key], reflectionTarget);
     }
+    return descriptor ?? target;
   };
 };
 

--- a/test/multi/multi-throttler.e2e-spec.ts
+++ b/test/multi/multi-throttler.e2e-spec.ts
@@ -22,7 +22,7 @@ describe.each`
   adapter           | name
   ${ExpressAdapter} | ${'express'}
   ${FastifyAdapter} | ${'fastify'}
-`('Mutli-Throttler Named Usage - $name', ({ adapter }: { adapter: Type<AbstractHttpAdapter> }) => {
+`('Multi-Throttler Named Usage - $name', ({ adapter }: { adapter: Type<AbstractHttpAdapter> }) => {
   let app: INestApplication;
   beforeAll(async () => {
     const modRef = await Test.createTestingModule({
@@ -37,7 +37,7 @@ describe.each`
   });
 
   describe('Default Route: 1/s, 2/5s, 5/min', () => {
-    it('should receive an exception when firing 2 request swithin a second', async () => {
+    it('should receive an exception when firing 2 requests within a second', async () => {
       await spec()
         .get('/')
         .expectStatus(200)
@@ -78,7 +78,7 @@ describe.each`
     });
   });
   describe('skips', () => {
-    it('should skip theshort throttler', async () => {
+    it('should skip the short throttler', async () => {
       await spec().get('/skip-short').expectStatus(200).expectHeader(remainingHeader(), '1');
       await spec().get('/skip-short').expectStatus(200).expectHeader(remainingHeader(), '0');
     });
@@ -86,7 +86,12 @@ describe.each`
       await spec()
         .get('/skip-default-and-long')
         .expectStatus(200)
-        .expectHeader(remainingHeader(short), '0');
+        .expectHeader(remainingHeader(short), '0')
+        .expect((ctx) => {
+          const { headers } = ctx.res;
+          expect(headers[remainingHeader('default')]).toBeUndefined();
+          expect(headers[remainingHeader('long')]).toBeUndefined();
+        });
     });
   });
 });


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

When an object is passed to the `@SkipThrottle()` decorator, only the first key in the object is handled

Issue Number: #1729


## What is the new behavior?

All keys of the object passed to`@SkipThrottle()` are handled. This is fixed thanks to not `return`ing early from the loop, and refactoring the way we set the metadata target for the decorator


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

The only reason this would be breaking is if somehow someone was banking on us intentionally mishandling this.


## Other information
