### PR TITLE
Fix: Fixes bug where 'this' is undefined in 'getTracker','generateKey' methods of custom ThrottlerGuard

### DIFF
--- a/.changeset/famous-steaks-happen.md
+++ b/.changeset/famous-steaks-happen.md
@@ -1,0 +1,5 @@
+---
+'@nestjs/throttler': patch
+---
+
+Resolves a bug that cause 'this' to be undefined in the 'getTracker' and 'generateKey' methods of the custom ThrottlerGuard

--- a/src/throttler.guard.ts
+++ b/src/throttler.guard.ts
@@ -60,8 +60,8 @@ export class ThrottlerGuard implements CanActivate {
         generateKey: this.options.generateKey,
       };
     }
-    this.commonOptions.getTracker ??= this.getTracker;
-    this.commonOptions.generateKey ??= this.generateKey;
+    this.commonOptions.getTracker ??= this.getTracker.bind(this);
+    this.commonOptions.generateKey ??= this.generateKey.bind(this);
   }
 
   /**


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: Closes #1808 


## What is the new behavior?

We bind the ThrottlerGuard instance to methods `getTracker` and `generateKey` with `bind(this)` making it accessible in `getTracker` and `generateKey` methods.


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

