### PR TITLE
refactor: set new expiresat on each request

### DIFF
--- a/src/throttler.service.ts
+++ b/src/throttler.service.ts
@@ -40,13 +40,9 @@ export class ThrottlerStorageService implements ThrottlerStorage, OnApplicationS
       this.storage[key] = { totalHits: 0, expiresAt: Date.now() + ttlMilliseconds };
     }
 
-    let timeToExpire = this.getExpirationTime(key);
-
     // Reset the timeToExpire once it has been expired.
-    if (timeToExpire <= 0) {
-      this.storage[key].expiresAt = Date.now() + ttlMilliseconds;
-      timeToExpire = this.getExpirationTime(key);
-    }
+    this.storage[key].expiresAt = Date.now() + ttlMilliseconds;
+    const timeToExpire = this.getExpirationTime(key);
 
     this.storage[key].totalHits++;
     this.setExpirationTime(key, ttlMilliseconds);


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
The `expiresAt` field is not updated while new requests are sent.

Issue Number: N/A


## What is the new behavior?
The `expiresAt` is updated on each request. That way we always calculate a new expiration time. 
As an example if I have `limit:2 `and `ttl: minutes(1)` a bot which sends multiple requests will be blocked and as long as it continues to send requests will be blocked(429 error).  The rate limit should go to 2 requests per minute to release the block(429 error).

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
