### PR TITLE
fix: use sha256 instead of md5 to support openssl 3.0 and on

### DIFF
--- a/.changeset/fifty-humans-remember.md
+++ b/.changeset/fifty-humans-remember.md
@@ -1,0 +1,5 @@
+---
+'@nestjs/throttler': minor
+---
+
+Swap MD5 hash for SHA256 to better support OpenSSL 3.0 and future iterations

--- a/src/hash.ts
+++ b/src/hash.ts
@@ -1,5 +1,5 @@
 import * as crypto from 'node:crypto';
 
-export function md5(text: string): string {
-  return crypto.createHash('md5').update(text).digest('hex');
+export function sha256(text: string): string {
+  return crypto.createHash('sha256').update(text).digest('hex');
 }

--- a/src/throttler.guard.ts
+++ b/src/throttler.guard.ts
@@ -1,6 +1,6 @@
 import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
-import { md5 } from './hash';
+import { sha256 } from './hash';
 import {
   Resolvable,
   ThrottlerGenerateKeyFunction,
@@ -217,7 +217,7 @@ export class ThrottlerGuard implements CanActivate {
    */
   protected generateKey(context: ExecutionContext, suffix: string, name: string): string {
     const prefix = `${context.getClass().name}-${context.getHandler().name}-${name}`;
-    return md5(`${prefix}-${suffix}`);
+    return sha256(`${prefix}-${suffix}`);
   }
 
   /**


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

OpenSSL 3.0+ has an issue with md5

Issue Number: #2094


## What is the new behavior?

Use sha256 instead of md5

## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

By some small technicality, this could be a breaking change in that the old keys will no longer be valid. That should be a rather small margin of users and for such a short period of time (presumably) that it shouldn't be an issue.


## Other information
