### PR TITLE
feat: pass context to get tracker fn as second arg

### DIFF
--- a/.changeset/blue-sheep-notice.md
+++ b/.changeset/blue-sheep-notice.md
@@ -1,0 +1,5 @@
+---
+'@nestjs/throttler': minor
+---
+
+pass context to getTraker as a second arg

--- a/src/throttler-module-options.interface.ts
+++ b/src/throttler-module-options.interface.ts
@@ -125,7 +125,10 @@ export interface ThrottlerAsyncOptions extends Pick<ModuleMetadata, 'imports'> {
 /**
  * @publicApi
  */
-export type ThrottlerGetTrackerFunction = (req: Record<string, any>) => Promise<string> | string;
+export type ThrottlerGetTrackerFunction = (
+  req: Record<string, any>,
+  context: ExecutionContext,
+) => Promise<string> | string;
 
 /**
  * @publicApi

--- a/src/throttler.guard.ts
+++ b/src/throttler.guard.ts
@@ -165,7 +165,7 @@ export class ThrottlerGuard implements CanActivate {
         }
       }
     }
-    const tracker = await getTracker(req);
+    const tracker = await getTracker(req, context);
     const key = generateKey(context, tracker, throttler.name);
     const { totalHits, timeToExpire, isBlocked, timeToBlockExpire } =
       await this.storageService.increment(key, ttl, limit, blockDuration, throttler.name);


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
I tried to make "dynamic" tracking with nestjs metadata for multiple scenarios. For example by default I want tracker to be `req.ip` value, but in some cases I want it to get the value from `req.body.username`. For a temporary solution I find that creating individual guards for each scenario, but if I have access to `ExecutionContext` I can get "key" from the metadata. Something like this:
```ts
// throttler-proxy.guard.ts
protected async getTracker(req: Record<string, any>, context: ExecutionContext): Promise<string> {
    const key = this.reflector.get(ThrottlerTracker, context.getHandler())
    const tracker = req?.[key] ?? req.ip
    return tracker
}

// throttler-tracker.decorator.ts
export const ThrottlerTracker = Reflector.createDecorator<string>();

// auth.controller.ts
@Post('login')
@ThrottlerTracker('body.username')
login () { ... }
```

Issue Number: N/A


## What is the new behavior?
Passes `ExecutionContext` to `getTracker` method as second argument. First time contributing to be honest, I hesitated to replace first param `req` to `context`.

## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
As I said it's my first time contributing hope you understand. Also not sure if it's a breaking change
