### PR TITLE
feat: Make resolveValue protected

### DIFF
--- a/src/throttler.guard.ts
+++ b/src/throttler.guard.ts
@@ -248,7 +248,7 @@ export class ThrottlerGuard implements CanActivate {
     return this.errorMessage;
   }
 
-  private async resolveValue<T extends number | string | boolean>(
+  protected async resolveValue<T extends number | string | boolean>(
     context: ExecutionContext,
     resolvableValue: Resolvable<T>,
   ): Promise<T> {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
Hey! It would be useful if resolveValue was protected instead of private, that way it can be used in Guards that extend ThrottlerGuard. Especially when canActivate is modified, we still need to process ThrottlerOptions, so having access to `super.resolveValue` would prevent repetitive code


## What is the new behavior?

`resolveValue` is callable from child classes
## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
