### PR TITLE
fix: avoid duplicate storage lifecycle hooks

### DIFF
--- a/src/throttler-module-options.interface.ts
+++ b/src/throttler-module-options.interface.ts
@@ -89,7 +89,7 @@ export type ThrottlerModuleOptions =
         | ((context: ExecutionContext, throttlerLimitDetail: ThrottlerLimitDetail) => string);
 
       /**
-       * The storage class to use where all the record will be stored in.
+       * The storage instance to use where all the records will be stored.
        */
       storage?: ThrottlerStorage;
       /**

--- a/src/throttler.module.spec.ts
+++ b/src/throttler.module.spec.ts
@@ -1,0 +1,132 @@
+import { Injectable, Module, OnModuleInit } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import {
+  ThrottlerModuleOptions,
+  ThrottlerOptionsFactory,
+} from './throttler-module-options.interface';
+import { ThrottlerModule } from './throttler.module';
+import { ThrottlerStorageRecord } from './throttler-storage-record.interface';
+import { ThrottlerStorage } from './throttler-storage.interface';
+
+@Injectable()
+class CustomStorage implements ThrottlerStorage, OnModuleInit {
+  static onModuleInitCalls = 0;
+
+  onModuleInit() {
+    CustomStorage.onModuleInitCalls++;
+  }
+
+  async increment(): Promise<ThrottlerStorageRecord> {
+    return {
+      totalHits: 1,
+      timeToExpire: 1000,
+      isBlocked: false,
+      timeToBlockExpire: 0,
+    };
+  }
+}
+
+@Module({
+  providers: [CustomStorage],
+  exports: [CustomStorage],
+})
+class CustomStorageModule {}
+
+@Injectable()
+class CustomOptionsFactory implements ThrottlerOptionsFactory {
+  constructor(private readonly storage: CustomStorage) {}
+
+  createThrottlerOptions(): ThrottlerModuleOptions {
+    return {
+      throttlers: [{ limit: 1, ttl: 1000 }],
+      storage: this.storage,
+    };
+  }
+}
+
+@Module({
+  imports: [CustomStorageModule],
+  providers: [CustomOptionsFactory],
+  exports: [CustomOptionsFactory],
+})
+class CustomOptionsModule {}
+
+describe('ThrottlerModule', () => {
+  beforeEach(() => {
+    CustomStorage.onModuleInitCalls = 0;
+  });
+
+  it('calls custom storage onModuleInit once when provided by an async factory', async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [
+        ThrottlerModule.forRootAsync({
+          imports: [CustomStorageModule],
+          inject: [CustomStorage],
+          useFactory: (storage: CustomStorage) => ({
+            throttlers: [{ limit: 1, ttl: 1000 }],
+            storage,
+          }),
+        }),
+      ],
+    }).compile();
+
+    await moduleRef.init();
+
+    expect(CustomStorage.onModuleInitCalls).toBe(1);
+
+    await moduleRef.close();
+  });
+
+  it('calls custom storage onModuleInit once when configured with useClass', async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [
+        ThrottlerModule.forRootAsync({
+          imports: [CustomStorageModule],
+          useClass: CustomOptionsFactory,
+        }),
+      ],
+    }).compile();
+
+    await moduleRef.init();
+
+    expect(CustomStorage.onModuleInitCalls).toBe(1);
+
+    await moduleRef.close();
+  });
+
+  it('calls custom storage onModuleInit once when configured with useExisting', async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [
+        ThrottlerModule.forRootAsync({
+          imports: [CustomOptionsModule],
+          useExisting: CustomOptionsFactory,
+        }),
+      ],
+    }).compile();
+
+    await moduleRef.init();
+
+    expect(CustomStorage.onModuleInitCalls).toBe(1);
+
+    await moduleRef.close();
+  });
+
+  it('delegates calls to custom storage passed directly in options', async () => {
+    const storage = new CustomStorage();
+    const incrementSpy = jest.spyOn(storage, 'increment');
+    const moduleRef = await Test.createTestingModule({
+      imports: [
+        ThrottlerModule.forRoot({
+          throttlers: [{ limit: 1, ttl: 1000 }],
+          storage,
+        }),
+      ],
+    }).compile();
+
+    await moduleRef.get(ThrottlerStorage).increment('key', 1000, 1, 1000, 'default');
+
+    expect(incrementSpy).toHaveBeenCalledWith('key', 1000, 1, 1000, 'default');
+
+    await moduleRef.close();
+  });
+});

--- a/src/throttler.providers.ts
+++ b/src/throttler.providers.ts
@@ -13,11 +13,21 @@ export function createThrottlerProviders(options: ThrottlerModuleOptions): Provi
   ];
 }
 
+// Custom storage may already be registered as a provider. Keep its lifecycle
+// hooks owned by that provider and expose only the storage contract here.
+class DelegatingThrottlerStorage implements ThrottlerStorage {
+  constructor(private readonly storage: ThrottlerStorage) {}
+
+  increment(...args: Parameters<ThrottlerStorage['increment']>) {
+    return this.storage.increment(...args);
+  }
+}
+
 export const ThrottlerStorageProvider = {
   provide: ThrottlerStorage,
   useFactory: (options: ThrottlerModuleOptions) => {
     return !Array.isArray(options) && options.storage
-      ? options.storage
+      ? new DelegatingThrottlerStorage(options.storage)
       : new ThrottlerStorageService();
   },
   inject: [THROTTLER_OPTIONS],


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

When a custom throttler storage instance is also registered as a Nest provider, `ThrottlerModule` exposes the same object again under the `ThrottlerStorage` token. Nest then treats both provider records as lifecycle-capable and calls hooks such as `onModuleInit` twice. This can happen with async options configured through `useFactory`, `useClass`, or `useExisting`.

Issue Number: Fixes #2408


## What is the new behavior?

Custom storage configured through module options is exposed through the `ThrottlerStorage` token by a small delegating storage wrapper. The original custom storage remains responsible for its own provider lifecycle, while throttler internals still call the public `increment()` storage contract.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


## Other information

Docs were not updated because this is a lifecycle bug fix with regression coverage.

Local validation:

```bash
pnpm test -- throttler.module.spec.ts --runInBand
pnpm exec jest --runInBand
pnpm build
pnpm exec eslint src/throttler.providers.ts src/throttler-module-options.interface.ts src/throttler.module.spec.ts
pnpm exec prettier --check src/throttler.providers.ts src/throttler-module-options.interface.ts src/throttler.module.spec.ts
git diff --check
```