### PR TITLE
fix: add a validation layer on increment method throttler service

### DIFF
--- a/src/throttler.service.spec.ts
+++ b/src/throttler.service.spec.ts
@@ -29,6 +29,43 @@ describe('ThrottlerStorageService', () => {
     expect(result.isBlocked).toBe(false);
   });
 
+  it('should coerce numeric string ttl and behave correctly', async () => {
+    // ConfigService.get<number>() returns strings from env vars — Number() must handle them
+    const result = await service.increment('test', '1000' as unknown as number, 10, 0, 'test');
+    expect(result.timeToExpire).toBe(1);
+    expect(result.totalHits).toBe(1);
+  });
+
+  it('should coerce numeric string limit and behave correctly', async () => {
+    const result = await service.increment('test', 1000, '10' as unknown as number, 0, 'test');
+    expect(result.isBlocked).toBe(false);
+    expect(result.totalHits).toBe(1);
+  });
+
+  it('should throw a descriptive error when ttl is a non-numeric string', async () => {
+    await expect(
+      service.increment('test', 'invalid' as unknown as number, 10, 0, 'test'),
+    ).rejects.toThrow('ThrottlerStorage: ttl must be a positive finite number, got "invalid"');
+  });
+
+  it('should throw a descriptive error when limit is a non-numeric string', async () => {
+    await expect(
+      service.increment('test', 1000, 'invalid' as unknown as number, 0, 'test'),
+    ).rejects.toThrow('ThrottlerStorage: limit must be a positive finite number, got "invalid"');
+  });
+
+  it('should throw when ttl is NaN', async () => {
+    await expect(service.increment('test', NaN, 10, 0, 'test')).rejects.toThrow(
+      'ThrottlerStorage: ttl must be a positive finite number',
+    );
+  });
+
+  it('should throw when ttl is zero or negative', async () => {
+    await expect(service.increment('test', 0, 10, 0, 'test')).rejects.toThrow(
+      'ThrottlerStorage: ttl must be a positive finite number',
+    );
+  });
+
   it('keys should be independent of each other over blocking and unblocking', async () => {
     // this test was added to specifically test the behavior of unblocking a key while
     // another key has active timeouts. These timeouts should not be affected since

--- a/src/throttler.service.ts
+++ b/src/throttler.service.ts
@@ -78,8 +78,22 @@ export class ThrottlerStorageService implements ThrottlerStorage, OnApplicationS
     blockDuration: number,
     throttlerName: string,
   ): Promise<ThrottlerStorageRecord> {
-    const ttlMilliseconds = ttl;
-    const blockDurationMilliseconds = blockDuration;
+    const ttlMilliseconds = Number(ttl);
+    const blockDurationMilliseconds = Number(blockDuration);
+    const resolvedLimit = Number(limit);
+
+    if (!Number.isFinite(ttlMilliseconds) || ttlMilliseconds <= 0) {
+      throw new Error(
+        `ThrottlerStorage: ttl must be a positive finite number, got "${ttl}". ` +
+          'If using ConfigService, ensure the value is parsed with Number() before passing to ThrottlerModule.',
+      );
+    }
+    if (!Number.isFinite(resolvedLimit) || resolvedLimit <= 0) {
+      throw new Error(
+        `ThrottlerStorage: limit must be a positive finite number, got "${limit}". ` +
+          'If using ConfigService, ensure the value is parsed with Number() before passing to ThrottlerModule.',
+      );
+    }
 
     if (!this.timeoutIds.has(key)) {
       this.timeoutIds.set(key, []);
@@ -108,7 +122,7 @@ export class ThrottlerStorageService implements ThrottlerStorage, OnApplicationS
 
     // Reset the blockExpiresAt once it gets blocked
     if (
-      this.storage.get(key).totalHits.get(throttlerName) > limit &&
+      this.storage.get(key).totalHits.get(throttlerName) > resolvedLimit &&
       !this.storage.get(key).isBlocked
     ) {
       this.storage.get(key).isBlocked = true;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
ThrottlerStorageService.increment() accepts ttl, limit, and blockDuration typed as                                                                                  
  number, but performs no runtime validation. When these values arrive as strings                                                                                       
  (e.g. from NestJS ConfigService.get<number>(), which does not coerce types at                                                                                         
  runtime), JavaScript silently performs string concatenation instead of numeric                                                                                        
  addition:                                                                                                                                                             
                                                                                                                                                                        
    Date.now() + "60000" → "178272505300060000"   // concatenation, not addition                                                                                        
                                                                                                                                                                        
  This corrupts expiresAt, causing timeToExpire and the X-RateLimit-Reset response                                                                                      
  header to return values in the trillions of seconds. The app starts successfully                                                                                    
  with no error or warning, making the bug extremely difficult to diagnose.                                                                                             
                                                                                                                                                                        
  Issue Number: (link the issue you raised)
Issue Number: #2626 


## What is the new behavior?
 increment() coerces ttl, limit, and blockDuration with Number() before use.
                                                                                                                                                                        
  - Valid numeric strings (e.g. "60000") are coerced correctly — no behaviour change                                                                                    
    for these inputs.                                                                                                                                                   
  - Non-numeric strings (e.g. "invalid"), NaN, zero, and negative values throw                                                                                          
    immediately with a descriptive error that names the bad value and points to                                                                                       
    ConfigService as the likely cause:                                                                                                                                  
                                                                                                                                                                      
    ThrottlerStorage: ttl must be a positive finite number, got "invalid".                                                                                              
    If using ConfigService, ensure the value is parsed with Number() before                                                                                           
    passing to ThrottlerModule.                                               


## Does this PR introduce a breaking change?
- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
