### PR TITLE
fix: avoid per-hit storage timers

### DIFF
--- a/.changeset/timer-free-storage.md
+++ b/.changeset/timer-free-storage.md
@@ -1,0 +1,5 @@
+---
+'@nestjs/throttler': patch
+---
+
+Avoid creating per-hit timers in the default in-memory storage.

--- a/src/throttler.service.spec.ts
+++ b/src/throttler.service.spec.ts
@@ -17,6 +17,12 @@ describe('ThrottlerStorageService', () => {
     service = modRef.get<ThrottlerStorageService>(ThrottlerStorage);
   });
 
+  afterEach(() => {
+    jest.restoreAllMocks();
+    service.onApplicationShutdown();
+    jest.useRealTimers();
+  });
+
   it('should have all of the providers defined', () => {
     expect(service).toBeDefined();
   });
@@ -29,11 +35,34 @@ describe('ThrottlerStorageService', () => {
     expect(result.isBlocked).toBe(false);
   });
 
+  it('should not create a timeout resource for each hit', async () => {
+    const setTimeoutSpy = jest.spyOn(global, 'setTimeout');
+
+    await service.increment('test', 1000, 3, 0, 'test');
+    await service.increment('test', 1000, 3, 0, 'test');
+
+    expect(setTimeoutSpy).not.toHaveBeenCalled();
+  });
+
+  it('should remove expired storage entries during periodic cleanup', async () => {
+    jest.useFakeTimers();
+    service.onApplicationShutdown();
+    service = new ThrottlerStorageService();
+
+    await service.increment('test', 1000, 3, 0, 'test');
+
+    expect(service.storage.has('test')).toBe(true);
+
+    jest.advanceTimersByTime(60_000);
+
+    expect(service.storage.has('test')).toBe(false);
+  });
+
   it('keys should be independent of each other over blocking and unblocking', async () => {
     // this test was added to specifically test the behavior of unblocking a key while
-    // another key has active timeouts. These timeouts should not be affected since
-    // they are critical for the throttler to function correctly.
-    // the sleep is smaller than the ttl so key1 always has timeouts that are waiting.
+    // another key has active hits. These hits should not be affected since they are
+    // critical for the throttler to function correctly.
+    // the sleep is smaller than the ttl so key1 always has hits that are waiting.
     // key2 will be throttled because it makes 4 requests every ttl window
     const ttl = 100;
     const blockDuration = 100;

--- a/src/throttler.service.ts
+++ b/src/throttler.service.ts
@@ -8,8 +8,19 @@ import { ThrottlerStorage } from './throttler-storage.interface';
  */
 @Injectable()
 export class ThrottlerStorageService implements ThrottlerStorage, OnApplicationShutdown {
+  private static readonly EXPIRATION_CLEANUP_INTERVAL_MS = 60_000;
+
   private _storage: Map<string, ThrottlerStorageOptions> = new Map();
-  private timeoutIds: Map<string, NodeJS.Timeout[]> = new Map();
+  private expirations: Map<string, Map<string, number[]>> = new Map();
+  private expirationCleanupIntervalId: NodeJS.Timeout;
+
+  constructor() {
+    this.expirationCleanupIntervalId = setInterval(
+      () => this.clearExpiredRecords(),
+      ThrottlerStorageService.EXPIRATION_CLEANUP_INTERVAL_MS,
+    );
+    this.expirationCleanupIntervalId.unref?.();
+  }
 
   get storage(): Map<string, ThrottlerStorageOptions> {
     return this._storage;
@@ -30,45 +41,62 @@ export class ThrottlerStorageService implements ThrottlerStorage, OnApplicationS
   }
 
   /**
-   * Set the expiration time for a given key.
-   */
-  private setExpirationTime(key: string, ttlMilliseconds: number, throttlerName: string): void {
-    const timeoutId = setTimeout(() => {
-      const { totalHits } = this.storage.get(key);
-      totalHits.set(throttlerName, totalHits.get(throttlerName) - 1);
-      clearTimeout(timeoutId);
-      this.timeoutIds.set(
-        key,
-        this.timeoutIds.get(key).filter((id) => id !== timeoutId),
-      );
-    }, ttlMilliseconds);
-    this.timeoutIds.get(key).push(timeoutId);
-  }
-
-  /**
-   * Clear the expiration time related to the throttle
-   */
-  private clearExpirationTimes(key: string) {
-    this.timeoutIds.get(key).forEach(clearTimeout);
-    this.timeoutIds.set(key, []);
-  }
-
-  /**
    * Reset the request blockage
    */
   private resetBlockedRequest(key: string, throttlerName: string) {
     this.storage.get(key).isBlocked = false;
     this.storage.get(key).totalHits.set(throttlerName, 0);
-    this.clearExpirationTimes(key);
+    this.expirations.get(key).set(throttlerName, []);
   }
 
   /**
-   * Increase the `totalHit` count and sent it to decrease queue
+   * Increase the `totalHit` count and register when it expires.
    */
   private fireHitCount(key: string, throttlerName: string, ttl: number) {
     const { totalHits } = this.storage.get(key);
     totalHits.set(throttlerName, totalHits.get(throttlerName) + 1);
-    this.setExpirationTime(key, ttl, throttlerName);
+    this.expirations
+      .get(key)
+      .get(throttlerName)
+      .push(Date.now() + ttl);
+  }
+
+  private ensureThrottlerNameEntry(key: string, throttlerName: string): void {
+    if (!this.storage.get(key).totalHits.has(throttlerName)) {
+      this.storage.get(key).totalHits.set(throttlerName, 0);
+    }
+
+    if (!this.expirations.get(key).has(throttlerName)) {
+      this.expirations.get(key).set(throttlerName, []);
+    }
+  }
+
+  private pruneExpiredHits(key: string, throttlerName: string): void {
+    const now = Date.now();
+    const expirations = this.expirations.get(key).get(throttlerName);
+    const unexpiredExpirations = expirations.filter((expiresAt) => expiresAt > now);
+
+    this.expirations.get(key).set(throttlerName, unexpiredExpirations);
+    this.storage.get(key).totalHits.set(throttlerName, unexpiredExpirations.length);
+  }
+
+  private clearExpiredRecords(): void {
+    for (const [key, expirations] of this.expirations) {
+      for (const throttlerName of expirations.keys()) {
+        this.pruneExpiredHits(key, throttlerName);
+      }
+
+      const record = this.storage.get(key);
+      const hasActiveHits = Array.from(record.totalHits.values()).some(
+        (totalHits) => totalHits > 0,
+      );
+      const isBlocked = record.isBlocked && record.blockExpiresAt > Date.now();
+
+      if (!hasActiveHits && !isBlocked) {
+        this.storage.delete(key);
+        this.expirations.delete(key);
+      }
+    }
   }
 
   async increment(
@@ -81,10 +109,6 @@ export class ThrottlerStorageService implements ThrottlerStorage, OnApplicationS
     const ttlMilliseconds = ttl;
     const blockDurationMilliseconds = blockDuration;
 
-    if (!this.timeoutIds.has(key)) {
-      this.timeoutIds.set(key, []);
-    }
-
     if (!this.storage.has(key)) {
       this.storage.set(key, {
         totalHits: new Map([[throttlerName, 0]]),
@@ -92,7 +116,11 @@ export class ThrottlerStorageService implements ThrottlerStorage, OnApplicationS
         blockExpiresAt: 0,
         isBlocked: false,
       });
+      this.expirations.set(key, new Map([[throttlerName, []]]));
     }
+    this.ensureThrottlerNameEntry(key, throttlerName);
+
+    this.pruneExpiredHits(key, throttlerName);
 
     let timeToExpire = this.getExpirationTime(key);
 
@@ -132,6 +160,7 @@ export class ThrottlerStorageService implements ThrottlerStorage, OnApplicationS
   }
 
   onApplicationShutdown() {
-    this.timeoutIds.forEach((timeouts) => timeouts.forEach(clearTimeout));
+    clearInterval(this.expirationCleanupIntervalId);
+    this.expirations.clear();
   }
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

The default in-memory storage schedules one `setTimeout()` for every counted hit. Those timers are created on the request path and can retain the active `AsyncLocalStorage` store until the hit TTL expires.

Issue Number: Fixes #2629


## What is the new behavior?

`ThrottlerStorageService` now stores hit expiration timestamps instead of scheduling per-hit timers. Expired hits are pruned on `increment()`, and a single unref'd cleanup interval removes idle storage records so expired hit state is bounded even when a key receives no further requests.


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


## Other information

Docs were not updated because this is a default in-memory storage bug fix with regression coverage.

Validated with:

```bash
pnpm exec jest src/throttler.service.spec.ts --runInBand
pnpm exec jest --runInBand
pnpm build
pnpm test:e2e --runInBand
pnpm exec eslint src/throttler.service.ts src/throttler.service.spec.ts
pnpm exec prettier --check src/throttler.service.ts src/throttler.service.spec.ts .changeset/timer-free-storage.md
git diff --check
```
