### PR TITLE
fix: support async options types on nest 12

### DIFF
--- a/.changeset/tidy-cats-import.md
+++ b/.changeset/tidy-cats-import.md
@@ -1,0 +1,5 @@
+---
+'@nestjs/throttler': patch
+---
+
+Import shared interfaces from the public Nest package entry point for Nest 12 compatibility.

--- a/src/throttler-module-options.interface.ts
+++ b/src/throttler-module-options.interface.ts
@@ -1,10 +1,9 @@
-import { ExecutionContext, ModuleMetadata, Type } from '@nestjs/common/interfaces';
+import { ExecutionContext, ModuleMetadata, Type } from '@nestjs/common';
 import { ThrottlerStorage } from './throttler-storage.interface';
 import { ThrottlerLimitDetail } from './throttler.guard.interface';
 
 export type Resolvable<T extends number | string | boolean> =
-  | T
-  | ((context: ExecutionContext) => T | Promise<T>);
+  T | ((context: ExecutionContext) => T | Promise<T>);
 
 /**
  * @publicApi


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

NestJS 12 no longer exports `@nestjs/common/interfaces`. The emitted throttler declaration imports
`ModuleMetadata` from that deep path, so TypeScript loses the optional `imports` property and a normal
`ThrottlerModule.forRootAsync({ useFactory: ... })` configuration fails to build unless consumers add
an unused `imports: []`.

Issue Number: Fixes #2671

## What is the new behavior?

Shared Nest interfaces are imported from the public `@nestjs/common` entry point. The published
declaration retains the correct optional `ModuleMetadata.imports` type on NestJS 12 while remaining
compatible with earlier supported Nest versions.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Verified with the public reproduction from #2671:

- Generated a strict ESM project with `@nestjs/cli@12.0.0`.
- Confirmed `pnpm build` fails with `@nestjs/throttler@6.5.0`.
- Packed this branch and installed the tarball into that project.
- Confirmed build and generated Vitest tests pass.
- Confirmed runtime throttling returns `200`, `200`, then `429` for a limit of two.
- Ran `pnpm lint`, `pnpm build`, `pnpm test:cov`, and `pnpm test:e2e` in this repository.

No repository test was added because the failure only occurs when the emitted declaration is consumed
with NestJS 12, while this repository's current development and CI dependencies remain on NestJS 11.
The minimum consumer reproduction is linked from #2671.
