### PR TITLE
ci: pin the release workflow so it stops drifting from ci.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,18 +11,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@master
+        uses: actions/checkout@v7
         with:
           # This makes Actions fetch all Git history so that Changesets can generate changelogs with the correct commits
           fetch-depth: 0
 
-      - name: Setup Node.js 20.x
-        uses: actions/setup-node@master
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
         with:
           node-version: 24.x
 
       - name: Install PNPM
-        run: npm i -g pnpm
+        run: npm i -g pnpm@^10
 
       - name: Install Dependencies
         run: pnpm i

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@nestjs/throttler",
   "version": "6.5.1",
+  "packageManager": "pnpm@10.34.5",
   "description": "A Rate-Limiting module for NestJS to work on Express, Fastify, Websockets, Socket.IO, and GraphQL, all rolled up into a simple package.",
   "author": "Jay McDoniel <me@jaymcdoniel.dev>",
   "contributors": [],


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

The Release workflow has been failing at `Install Dependencies` and never reaches the build or publish step. Full detail, logs and measurements are in the issue.

Issue Number: #2674

Short version: `release.yml` installs pnpm with an unpinned `npm i -g pnpm`, so it follows npm's `latest`. pnpm 11.0.0 flipped `strictDepBuilds` to `true` by default, which turns the "Ignored build scripts" warning into a non-zero exit. `ci.yml` pins `pnpm@^9` and never noticed, so the same commit is green in CI and red in Release.

## What is the new behavior?

Five lines, all of them the same subject: nothing in `release.yml` was pinned, so it drifted.

| line | before | after |
| --- | --- | --- |
| checkout | `actions/checkout@master` | `actions/checkout@v7` |
| setup node | `actions/setup-node@master` | `actions/setup-node@v7` |
| step name | `Setup Node.js 20.x` | `Setup Node.js` |
| pnpm | `npm i -g pnpm` | `npm i -g pnpm@^10` |
| package.json | none | `"packageManager": "pnpm@10.34.5"` |

`v7` is what `ci.yml` already uses for both actions, so this only brings the two files back in line. The step name asked for `24.x` while calling itself `20.x`.

**Why pnpm 10 and not 9 or 11.** `@changesets/cli` v3, which Renovate moved this repo to in August, declares its own floor in `engines`:

```json
"engines": { "node": "^22.11 || ^24 || >=26", "npm": ">=10.9.0", "pnpm": ">=10.0.0", "yarn": ">=4.5.2" }
```

so pinning to 9 would contradict the release tool itself. pnpm 10 prints the ignored build scripts notice as a warning and exits 0, so the release path completes without this PR having to decide anything about `@apollo/protobufjs`'s build scripts. Should you prefer to answer that question rather than stay on 10, the pnpm 11 way is an `allowBuilds` entry in `pnpm-workspace.yaml`, and note that the file then also needs `packages: []` or `ci.yml`'s pnpm 9 fails with `packages field missing or empty`. Happy to switch this PR to that shape instead.

**Why the `packageManager` field.** It is what stops the two workflows from diverging again, and it pulls contributors onto the same pnpm without either YAML file repeating the version. Verified that pnpm 11 honours it by self switching rather than erroring.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

## Other information

Verified locally on Node 24.20, one clean install per case:

| case | result |
| --- | --- |
| `pnpm@10.34.5`, the new release path | install exit 0, build exit 0, 46 files in `dist` |
| `pnpm@11.25.0`, a future unpinned runner | self switches to 10.34.5, install exit 0 |
| `pnpm@^9`, today's `ci.yml`, unchanged | install exit 0 |

and the full CI script set on `pnpm@9.15.9` so this does not disturb CI: `lint`, `build`, `test:cov` (4 suites, 33 tests) and `test:e2e` (2 suites, 11 tests) all pass.

No changeset, matching how `chore(deps)` commits touch `package.json` in this repo.

**This makes the pipeline run again, it does not publish.** Two things still sit in front of npm and neither belongs in this PR:

- With a changeset present, `changesets/action` takes the `runVersion` path, so a green install produces a Version Packages PR rather than a publish.
- `changesets/action@master` is frozen at a 2021 commit and declares `runs: using: "node12"`, while this repo is now on Changesets CLI v3. I opened a separate issue for that, since the npm authentication half of it overlaps #2532.
